### PR TITLE
update definition of iseq_external_product_metric table

### DIFF
--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductMetric.pm
@@ -65,17 +65,22 @@ Datetime this record was created
 
 Datetime this record was created or changed
 
-=head2 supplier_sample_name_wsi
+=head2 sample_id_wsi
 
   data_type: 'varchar'
-  is_nullable: 0
+  is_nullable: 1
   size: 255
 
 =head2 plate_id_wsi
 
   data_type: 'varchar'
-  is_nullable: 0
-  size: 20
+  is_nullable: 1
+  size: 255
+
+=head2 library_id_wsi
+
+  data_type: 'integer'
+  is_nullable: 1
 
 =head2 file_name_wsi
 
@@ -96,8 +101,8 @@ Comma-delimitered alphabetically sorted list of full file paths for the files in
 =head2 md5_wsi
 
   data_type: 'char'
-  is_nullable: 0
-  size: 24
+  is_nullable: 1
+  size: 32
 
 WSI validation hex MD5, not set for multiple source files
 
@@ -107,15 +112,15 @@ WSI validation hex MD5, not set for multiple source files
   is_nullable: 1
   size: 15
 
-One of 'IN PROGRESS', 'DONE', 'FAILED', not set for multiple source files
+One of 'IN PROGRESS', 'DONE', 'FAIL', not set for multiple source files
 
-=head2 manifest_upload_date
+=head2 manifest_upload_status_change_date
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
   is_nullable: 1
 
-Date the manifest uploaded by WSI
+Date the status of manifest upload is changed
 
 =head2 id_iseq_product
 
@@ -230,7 +235,7 @@ Date of confirmation of integrity of data products by archive service
 
   data_type: 'char'
   is_nullable: 1
-  size: 24
+  size: 32
 
 External validation hex MD5, not set for multiple source files
 
@@ -588,19 +593,21 @@ __PACKAGE__->add_columns(
     default_value => 'CURRENT_TIMESTAMP',
     is_nullable => 1,
   },
-  'supplier_sample_name_wsi',
-  { data_type => 'varchar', is_nullable => 0, size => 255 },
+  'sample_id_wsi',
+  { data_type => 'varchar', is_nullable => 1, size => 255 },
   'plate_id_wsi',
-  { data_type => 'varchar', is_nullable => 0, size => 20 },
+  { data_type => 'varchar', is_nullable => 1, size => 255 },
+  'library_id_wsi',
+  { data_type => 'integer', is_nullable => 1 },
   'file_name_wsi',
   { data_type => 'varchar', is_nullable => 0, size => 300 },
   'file_path_wsi',
   { data_type => 'varchar', is_nullable => 0, size => 760 },
   'md5_wsi',
-  { data_type => 'char', is_nullable => 0, size => 24 },
+  { data_type => 'char', is_nullable => 1, size => 32 },
   'manifest_upload_status',
   { data_type => 'char', is_nullable => 1, size => 15 },
-  'manifest_upload_date',
+  'manifest_upload_status_change_date',
   {
     data_type => 'datetime',
     datetime_undef_if_invalid => 1,
@@ -640,7 +647,7 @@ __PACKAGE__->add_columns(
   'archive_conformation_date',
   { data_type => 'date', datetime_undef_if_invalid => 1, is_nullable => 1 },
   'md5',
-  { data_type => 'char', is_nullable => 1, size => 24 },
+  { data_type => 'char', is_nullable => 1, size => 32 },
   'md5_validation',
   { data_type => 'char', is_nullable => 1, size => 4 },
   'format_validation',
@@ -748,18 +755,6 @@ __PACKAGE__->set_primary_key('id_iseq_ext_pr_metrics_tmp');
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<iseq_ext_pr_metrics_pr_file_name>
-
-=over 4
-
-=item * L</file_name_wsi>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint('iseq_ext_pr_metrics_pr_file_name', ['file_name_wsi']);
-
 =head2 C<iseq_ext_pr_metrics_pr_file_path>
 
 =over 4
@@ -810,8 +805,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-09-11 11:38:00
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CV+8Boi5Z2/Pnz4R+PPHuQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-09-27 11:05:25
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:if5zN5/t8/basEUnVFndjA
 
 our $VERSION = '0';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductMetric.pm
@@ -65,40 +65,46 @@ Datetime this record was created
 
 Datetime this record was created or changed
 
-=head2 sample_id_wsi
+=head2 supplier_sample_name
 
   data_type: 'varchar'
   is_nullable: 1
   size: 255
 
-=head2 plate_id_wsi
+Sample name given by the supplier, as recorded by WSI
+
+=head2 plate_barcode
 
   data_type: 'varchar'
   is_nullable: 1
   size: 255
 
-=head2 library_id_wsi
+Stock plate barcode, as recorded by WSI
+
+=head2 library_id
 
   data_type: 'integer'
   is_nullable: 1
 
-=head2 file_name_wsi
+WSI library identifier
+
+=head2 file_name
 
   data_type: 'varchar'
   is_nullable: 0
   size: 300
 
-Comma-delimitered alphabetically sorted list of file names, which unambigiously define DNAP sources of data
+Comma-delimitered alphabetically sorted list of file names, which unambigiously define WSI sources of data
 
-=head2 file_path_wsi
+=head2 file_path
 
   data_type: 'varchar'
   is_nullable: 0
   size: 760
 
-Comma-delimitered alphabetically sorted list of full file paths for the files in file_names column
+Comma-delimitered alphabetically sorted list of full external file paths for the files in file_names column as uploaded by WSI
 
-=head2 md5_wsi
+=head2 md5_staging
 
   data_type: 'char'
   is_nullable: 1
@@ -112,7 +118,7 @@ WSI validation hex MD5, not set for multiple source files
   is_nullable: 1
   size: 15
 
-One of 'IN PROGRESS', 'DONE', 'FAIL', not set for multiple source files
+WSI manifest upload status, one of 'IN PROGRESS', 'DONE', 'FAIL', not set for multiple source files
 
 =head2 manifest_upload_status_change_date
 
@@ -120,7 +126,7 @@ One of 'IN PROGRESS', 'DONE', 'FAIL', not set for multiple source files
   datetime_undef_if_invalid: 1
   is_nullable: 1
 
-Date the status of manifest upload is changed
+Date the status of manifest upload is changed by WSI
 
 =head2 id_iseq_product
 
@@ -593,17 +599,17 @@ __PACKAGE__->add_columns(
     default_value => 'CURRENT_TIMESTAMP',
     is_nullable => 1,
   },
-  'sample_id_wsi',
+  'supplier_sample_name',
   { data_type => 'varchar', is_nullable => 1, size => 255 },
-  'plate_id_wsi',
+  'plate_barcode',
   { data_type => 'varchar', is_nullable => 1, size => 255 },
-  'library_id_wsi',
+  'library_id',
   { data_type => 'integer', is_nullable => 1 },
-  'file_name_wsi',
+  'file_name',
   { data_type => 'varchar', is_nullable => 0, size => 300 },
-  'file_path_wsi',
+  'file_path',
   { data_type => 'varchar', is_nullable => 0, size => 760 },
-  'md5_wsi',
+  'md5_staging',
   { data_type => 'char', is_nullable => 1, size => 32 },
   'manifest_upload_status',
   { data_type => 'char', is_nullable => 1, size => 15 },
@@ -755,17 +761,17 @@ __PACKAGE__->set_primary_key('id_iseq_ext_pr_metrics_tmp');
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<iseq_ext_pr_metrics_pr_file_path>
+=head2 C<iseq_ext_pr_file_path>
 
 =over 4
 
-=item * L</file_path_wsi>
+=item * L</file_path>
 
 =back
 
 =cut
 
-__PACKAGE__->add_unique_constraint('iseq_ext_pr_metrics_pr_file_path', ['file_path_wsi']);
+__PACKAGE__->add_unique_constraint('iseq_ext_pr_file_path', ['file_path']);
 
 =head1 RELATIONS
 
@@ -805,8 +811,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-09-27 11:05:25
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:if5zN5/t8/basEUnVFndjA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-09-27 12:49:23
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fxS/fUz+yDo83wX1X2NKvw
 
 our $VERSION = '0';
 

--- a/scripts/update_schema_6.1.sql
+++ b/scripts/update_schema_6.1.sql
@@ -1,19 +1,35 @@
 ALTER TABLE `iseq_external_product_metrics`
   DROP KEY `iseq_ext_pr_sample_name`,
   DROP KEY `iseq_ext_pr_metrics_pr_file_name`,
+  DROP KEY `iseq_ext_pr_metrics_pr_file_path`,
+  DROP KEY `iseq_ext_pr_plate_id`,
+  CHANGE COLUMN `file_name_wsi` `file_name` \
+    varchar(300) NOT NULL \
+   COMMENT 'Comma-delimitered alphabetically sorted list of file names, which unambigiously define WSI sources of data',
+  CHANGE COLUMN `file_path_wsi` `file_path` \
+   varchar(760) NOT NULL \
+   COMMENT 'Comma-delimitered alphabetically sorted list of full external file paths for the files in file_names column as uploaded by WSI',
   MODIFY COLUMN `manifest_upload_status` char(15) DEFAULT NULL \
-    COMMENT 'One of "IN PROGRESS", "DONE", "FAIL", not set for multiple source files',
+    COMMENT 'WSI manifest upload status, one of "IN PROGRESS", "DONE", "FAIL", not set for multiple source files',
   CHANGE COLUMN `manifest_upload_date` `manifest_upload_status_change_date` \
     datetime DEFAULT NULL \
-    COMMENT 'Date the status of manifest upload is changed',
-  CHANGE COLUMN `supplier_sample_name_wsi` `sample_id_wsi` varchar(255) DEFAULT NULL,
-  MODIFY COLUMN `plate_id_wsi` varchar(255) DEFAULT NULL,
-  MODIFY COLUMN `md5_wsi` char(32) DEFAULT NULL \
+    COMMENT 'Date the status of manifest upload is changed by WSI',
+  CHANGE COLUMN `supplier_sample_name_wsi` `supplier_sample_name` \
+    varchar(255) DEFAULT NULL \
+    COMMENT 'Sample name given by the supplier, as recorded by WSI',
+  CHANGE COLUMN `plate_id_wsi` `plate_barcode` \
+    varchar(255) DEFAULT NULL \
+    COMMENT 'Stock plate barcode, as recorded by WSI',
+  CHANGE COLUMN `md5_wsi` `md5_staging` \
+    char(32) DEFAULT NULL \
     COMMENT 'WSI validation hex MD5, not set for multiple source files',
-  ADD COLUMN `library_id_wsi` int(11) DEFAULT NULL \
-    AFTER `plate_id_wsi`,
+  ADD COLUMN `library_id` int(11) DEFAULT NULL \
+    COMMENT 'WSI library identifier' \
+    AFTER `plate_barcode`,
   MODIFY COLUMN `md5` char(32) DEFAULT NULL \
     COMMENT 'External validation hex MD5, not set for multiple source files',
-  ADD KEY `iseq_ext_pr_fname` (`file_name_wsi`),
-  ADD KEY `iseq_ext_pr_lib_id` (`library_id_wsi`),
-  ADD KEY `iseq_ext_pr_sample_id` (`sample_id_wsi`);
+  ADD UNIQUE KEY `iseq_ext_pr_file_path` (`file_path`),
+  ADD KEY `iseq_ext_pr_fname` (`file_name`),
+  ADD KEY `iseq_ext_pr_lib_id` (`library_id`),
+  ADD KEY `iseq_ext_pr_sample_name` (`supplier_sample_name`),
+  ADD KEY `iseq_ext_pr_plate_bc` (`plate_barcode`);

--- a/scripts/update_schema_6.1.sql
+++ b/scripts/update_schema_6.1.sql
@@ -1,0 +1,19 @@
+ALTER TABLE `iseq_external_product_metrics`
+  DROP KEY `iseq_ext_pr_sample_name`,
+  DROP KEY `iseq_ext_pr_metrics_pr_file_name`,
+  MODIFY COLUMN `manifest_upload_status` char(15) DEFAULT NULL \
+    COMMENT 'One of "IN PROGRESS", "DONE", "FAIL", not set for multiple source files',
+  CHANGE COLUMN `manifest_upload_date` `manifest_upload_status_change_date` \
+    datetime DEFAULT NULL \
+    COMMENT 'Date the status of manifest upload is changed',
+  CHANGE COLUMN `supplier_sample_name_wsi` `sample_id_wsi` varchar(255) DEFAULT NULL,
+  MODIFY COLUMN `plate_id_wsi` varchar(255) DEFAULT NULL,
+  MODIFY COLUMN `md5_wsi` char(32) DEFAULT NULL \
+    COMMENT 'WSI validation hex MD5, not set for multiple source files',
+  ADD COLUMN `library_id_wsi` int(11) DEFAULT NULL \
+    AFTER `plate_id_wsi`,
+  MODIFY COLUMN `md5` char(32) DEFAULT NULL \
+    COMMENT 'External validation hex MD5, not set for multiple source files',
+  ADD KEY `iseq_ext_pr_fname` (`file_name_wsi`),
+  ADD KEY `iseq_ext_pr_lib_id` (`library_id_wsi`),
+  ADD KEY `iseq_ext_pr_sample_id` (`sample_id_wsi`);


### PR DESCRIPTION
  - add library_id column
  - rename manifest_upload_date column to manifest_upload_status_change_date
  - rename file_name_wsi column to file_name and fila_path_wsi to file_path
  - rename supplier_sample_name_wsi column to supplier_sample_name
  - rename plate_id_wsi column to plate_barcode
  - rename md5_wsi column to md5_staging
  - make plate_barcode, md5_staging, sample_supplier_name columns nullable
  - drop unique constraint on file_name column
  - increase column size of md5 columns to char 32