### PR TITLE
Add run table to link iseq_flowcell and iseq_run_status tables

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+ - add iseq_run table to link run and flowcell identities with the
+  run folder name
+
 release 6.13.0
  - add tables pac_bio_run_well_metrics and pac_bio_product_metrics 
    to store metrics extracted from PacBio's SMRT Link LIMS

--- a/MANIFEST
+++ b/MANIFEST
@@ -38,6 +38,7 @@ t/00-distribution.t
 t/00-pod.t
 t/10-Schema.t
 t/10-Schema-IseqExternalProductMetric.t
+t/10-Schema-IseqRun.t
 t/20-Schema-Query-IseqFlowcell.t
 t/20-Schema-Query-LibraryDigest.t
 t/data/fixtures/00-IseqRunStatusDict.yml

--- a/MANIFEST
+++ b/MANIFEST
@@ -19,6 +19,7 @@ lib/WTSI/DNAP/Warehouse/Schema/Result/IseqHeronProductMetric.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductMetric.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqExternalProductComponent.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqProductComponent.pm
+lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRun.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRunLaneMetric.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRunStatus.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRunStatusDict.pm

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRun.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRun.pm
@@ -1,0 +1,149 @@
+
+package WTSI::DNAP::Warehouse::Schema::Result::IseqRun;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+WTSI::DNAP::Warehouse::Schema::Result::IseqRun - Table linking iseq_flowcell table to iseq_run_status table
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components('InflateColumn::DateTime');
+
+=head1 TABLE: C<iseq_run>
+
+=cut
+
+__PACKAGE__->table('iseq_run');
+
+=head1 ACCESSORS
+
+=head2 id_run
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 0
+
+NPG run identifier
+
+=head2 id_flowcell_lims
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 20
+
+LIMS specific flowcell id
+
+=head2 folder_name
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 64
+
+Runfolder name
+
+=cut
+
+__PACKAGE__->add_columns(
+  'id_run',
+  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 0 },
+  'id_flowcell_lims',
+  { data_type => 'varchar', is_nullable => 1, size => 20 },
+  'folder_name',
+  { data_type => 'varchar', is_nullable => 1, size => 64 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-30 10:23:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gdIbb8UoN0OHvFRDN+Xkng
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+
+our $VERSION = '0';
+
+__PACKAGE__->meta->make_immutable;
+1;
+__END__
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Result class definition in DBIx binding for the multi-lims warehouse database.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 SUBROUTINES/METHODS
+
+=head1 DEPENDENCIES
+
+=over
+
+=item strict
+
+=item warnings
+
+=item Moose
+
+=item MooseX::NonMoose
+
+=item MooseX::MarkAsMethods
+
+=item DBIx::Class::Core
+
+=item DBIx::Class::InflateColumn::DateTime
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Michael Kubiak E<lt>mk35@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2015 Genome Research Limited
+
+This file is part of the ml_warehouse package L<https://github.com/wtsi-npg/ml_warehouse>.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRun.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqRun.pm
@@ -6,7 +6,11 @@ package WTSI::DNAP::Warehouse::Schema::Result::IseqRun;
 
 =head1 NAME
 
-WTSI::DNAP::Warehouse::Schema::Result::IseqRun - Table linking iseq_flowcell table to iseq_run_status table
+WTSI::DNAP::Warehouse::Schema::Result::IseqRun
+
+=head1 DESCRIPTION
+
+Table linking run and flowcell identities with the run folder name
 
 =cut
 
@@ -73,9 +77,21 @@ __PACKAGE__->add_columns(
   { data_type => 'varchar', is_nullable => 1, size => 64 },
 );
 
+=head1 PRIMARY KEY
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-30 10:23:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gdIbb8UoN0OHvFRDN+Xkng
+=over 4
+
+=item * L</id_run>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key('id_run');
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-04-06 11:14:56
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZXwdsjfvNYCPvDydZNVf5w
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
@@ -128,7 +144,7 @@ Michael Kubiak E<lt>mk35@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 Genome Research Limited
+Copyright (C) 2021 Genome Research Limited
 
 This file is part of the ml_warehouse package L<https://github.com/wtsi-npg/ml_warehouse>.
 

--- a/scripts/update_schema_6.14.0.sql
+++ b/scripts/update_schema_6.14.0.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS `iseq_run`;
+CREATE TABLE `iseq_run` (
+  `id_run` int(10) unsigned NOT NULL COMMENT 'NPG run identifier',
+  `id_flowcell_lims` varchar(20) DEFAULT NULL COMMENT 'LIMS specific flowcell id',
+  `folder_name` varchar(64) DEFAULT NULL COMMENT 'Runfolder name'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 \
+  COMMENT 'Table linking iseq_flowcell table to iseq_run_status table';

--- a/scripts/update_schema_6.14.0.sql
+++ b/scripts/update_schema_6.14.0.sql
@@ -2,6 +2,8 @@ DROP TABLE IF EXISTS `iseq_run`;
 CREATE TABLE `iseq_run` (
   `id_run` int(10) unsigned NOT NULL COMMENT 'NPG run identifier',
   `id_flowcell_lims` varchar(20) DEFAULT NULL COMMENT 'LIMS specific flowcell id',
-  `folder_name` varchar(64) DEFAULT NULL COMMENT 'Runfolder name'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 \
-  COMMENT 'Table linking iseq_flowcell table to iseq_run_status table';
+  `folder_name` varchar(64) DEFAULT NULL COMMENT 'Runfolder name',
+  PRIMARY KEY (`id_run`),
+  KEY `iseq_run_id_flowcell_lims` (`id_flowcell_lims`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci\
+  COMMENT 'Table linking run and flowcell identities with the run folder name';

--- a/t/10-Schema-IseqRun.t
+++ b/t/10-Schema-IseqRun.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More tests => 7;
+use Test::Exception;
+
+use_ok('WTSI::DNAP::Warehouse::Schema');
+
+my $schema;
+lives_ok { $schema = WTSI::DNAP::Warehouse::Schema->connect('dbi:SQLite:dbname=:memory:') }
+  'connected to test in-memory database';
+lives_ok { $schema->deploy() } 'schema deployed';
+
+my $rs_run = $schema->resultset('IseqRun');
+
+lives_ok { $rs_run->create({id_run => 34726, folder_name => '34726_RUN_FOLDER_8374', id_flowcell_lims => 3847}) }
+	'inserted non-null values';
+
+is_deeply(\{$rs_run->find(34726)->get_columns},
+	\{id_run => 34726, folder_name => '34726_RUN_FOLDER_8374', id_flowcell_lims => 3847},
+	'retrieved a row');
+
+lives_ok { $rs_run->create({id_run => 80364, id_flowcell_lims => 3}) }
+	'inserted null value into folder_name column';
+
+lives_ok { $rs_run->find(80364)->update({folder_name => '80364_RUN_FOLDER_8272', id_flowcell_lims => 8372}) }
+	'updated values of a row';


### PR DESCRIPTION
The table is loaded from npg_tracking's run table, and contains:
- id_run
- id_flowcell_lims (batch_id in tracking)
- folder_name