### PR TITLE
Made product id columns not nullable.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 LIST OF CHANGES
 ---------------
 
+ - PacBio metrics tables:
+     1. make product id columns not nullable since LangQC relies
+        on these ids being available;
+     2 set collation for product ids so that it is possible to easily join
+       these tables to seq_product_irods_locations table.
+
 release 6.25.0
  - Add columns to the pac_bio_run_well_metrics and pac_bio_product_metrics
    to store QC state for PacBio wells and products

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
@@ -67,7 +67,7 @@ PacBio run id, see 'pac_bio_run.id_pac_bio_tmp'
 =head2 id_pac_bio_product
 
   data_type: 'char'
-  is_nullable: 1
+  is_nullable: 0
   size: 64
 
 Product id
@@ -89,7 +89,7 @@ __PACKAGE__->add_columns(
   'id_pac_bio_tmp',
   { data_type => 'integer', is_foreign_key => 1, is_nullable => 1 },
   'id_pac_bio_product',
-  { data_type => 'char', is_nullable => 1, size => 64 },
+  { data_type => 'char', is_nullable => 0, size => 64 },
   'qc',
   { data_type => 'tinyint', is_nullable => 1 },
 );
@@ -175,8 +175,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-01-18 17:31:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ix20OijwEPnkhHQ4fn8E6A
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-02-23 11:19:02
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:atOKMZwtqWTqeE7XYU1hlw
 
 our $VERSION = '0';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioRunWellMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioRunWellMetric.pm
@@ -51,7 +51,7 @@ __PACKAGE__->table('pac_bio_run_well_metrics');
 =head2 id_pac_bio_product
 
   data_type: 'char'
-  is_nullable: 1
+  is_nullable: 0
   size: 64
 
 Product id
@@ -552,7 +552,7 @@ __PACKAGE__->add_columns(
   'id_pac_bio_rw_metrics_tmp',
   { data_type => 'integer', is_auto_increment => 1, is_nullable => 0 },
   'id_pac_bio_product',
-  { data_type => 'char', is_nullable => 1, size => 64 },
+  { data_type => 'char', is_nullable => 0, size => 64 },
   'pac_bio_run_name',
   { data_type => 'varchar', is_nullable => 0, size => 255 },
   'well_label',
@@ -784,8 +784,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-01-18 17:31:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7sZ7xcwCbHMrz5gopGKxlA
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-02-23 11:12:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ibpsNGR8Zp+PA0gTvmPUkw
 
 our $VERSION = '0';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/Sample.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/Sample.pm
@@ -665,6 +665,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 gsu_sample_uploads
+
+Type: has_many
+
+Related object: L<WTSI::DNAP::Warehouse::Schema::Result::GsuSampleUpload>
+
+=cut
+
+__PACKAGE__->has_many(
+  'gsu_sample_uploads',
+  'WTSI::DNAP::Warehouse::Schema::Result::GsuSampleUpload',
+  { 'foreign.id_sample_tmp' => 'self.id_sample_tmp' },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 iseq_flowcells
 
 Type: has_many
@@ -771,8 +786,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-06-28 16:28:20
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:i/ZbSbPN+YJN/KVOkyNMqA
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-02-23 11:12:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mDkQ0kpnyj+FNE+gMXM8Pg
 
 our $VERSION = '0';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/Study.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/Study.pm
@@ -481,6 +481,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 gsu_sample_uploads
+
+Type: has_many
+
+Related object: L<WTSI::DNAP::Warehouse::Schema::Result::GsuSampleUpload>
+
+=cut
+
+__PACKAGE__->has_many(
+  'gsu_sample_uploads',
+  'WTSI::DNAP::Warehouse::Schema::Result::GsuSampleUpload',
+  { 'foreign.id_study_tmp' => 'self.id_study_tmp' },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 iseq_flowcells
 
 Type: has_many
@@ -557,8 +572,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-06-03 13:17:44
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZUb0NzmfNR9Gxza74GVPFw
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-02-23 11:12:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NrXlvzwGR2uLtnN+fJVHvw
 
 with 'WTSI::DNAP::Warehouse::Schema::Query::LimsFlags';
 

--- a/scripts/update_schema_6.26.0.sql
+++ b/scripts/update_schema_6.26.0.sql
@@ -1,0 +1,13 @@
+-- Make product id columns not nullable since LangQC relies
+-- on these ids being available.
+-- Set collation for product ids so that it is possible to
+-- easily join PacBio tables to the seq_product_irods_locations
+-- table.
+
+ALTER TABLE `pac_bio_run_well_metrics` \
+  MODIFY COLUMN `id_pac_bio_product` char(64) \
+  COLLATE utf8_unicode_ci NOT NULL COMMENT 'Product id';
+
+ALTER TABLE `pac_bio_product_metrics` \
+  MODIFY COLUMN `id_pac_bio_product` char(64) \
+  COLLATE utf8_unicode_ci NOT NULL COMMENT 'Product id';  


### PR DESCRIPTION
Made product id columns in PacBio metrics tables since LangQC relies on these ids being available.
Set collation for product ids so that it is possible to easily join these tables to seq_product_irods_locations table.

Might need to patch db test fixtures in some other packages. This pr cannot be merged until then. 

Tests in npg_ml_warehouse and npg_irods run OK
Tests in the mlwh Pyron ORM run OK