### PR TITLE
Add columns to pac_bio_product_metrics

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ LIST OF CHANGES
 
  - Additional columns added to the iseq_product_metrics table to support
    BGE library metrics reporting.
+ - Add columns to pac_bio_product_metrics to store tag level yield
+   related metrics and bring other tables up to date
 
 release 6.30.0
  - To help with detecting recent changes, add `last_changed` column

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/LabwareLocation.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/LabwareLocation.pm
@@ -68,6 +68,15 @@ Barcode associated with storage location
 
 Fully qualifed address of the nested location
 
+=head2 location_name
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 255
+
+Name of location where labware is stored
+
 =head2 coordinate_position
 
   data_type: 'integer'
@@ -136,6 +145,8 @@ __PACKAGE__->add_columns(
   { data_type => 'varchar', is_nullable => 0, size => 255 },
   'full_location_address',
   { data_type => 'varchar', is_nullable => 0, size => 255 },
+  'location_name',
+  { data_type => 'varchar', default_value => '', is_nullable => 0, size => 255 },
   'coordinate_position',
   { data_type => 'integer', is_nullable => 1 },
   'coordinate_row',
@@ -196,8 +207,8 @@ __PACKAGE__->add_unique_constraint(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-07-21 23:04:20
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CRLExOSkBH1meg87TdA4+g
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-01-19 13:58:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MlRPMXGHbVYnpWjeFULpXQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
@@ -79,6 +79,53 @@ Product id
 
 The final QC outcome of the product as 0(failed), 1(passed) or NULL
 
+=head2 hifi_read_bases
+
+  data_type: 'bigint'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+The number of HiFi bases
+
+=head2 hifi_num_reads
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+The number of HiFi reads
+
+=head2 hifi_read_length_mean
+
+  data_type: 'integer'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+The mean HiFi read length
+
+=head2 barcode_quality_score_mean
+
+  data_type: 'smallint'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+The mean barcode HiFi quality score
+
+=head2 hifi_read_quality_mean
+
+  data_type: 'smallint'
+  extra: {unsigned => 1}
+  is_nullable: 1
+
+The mean HiFi base quality
+
+=head2 hifi_bases_percent
+
+  data_type: 'float'
+  is_nullable: 1
+
+The HiFi bases expressed as a percentage of the total HiFi bases
+
 =head2 last_changed
 
   data_type: 'datetime'
@@ -101,6 +148,18 @@ __PACKAGE__->add_columns(
   { data_type => 'char', is_nullable => 0, size => 64 },
   'qc',
   { data_type => 'tinyint', is_nullable => 1 },
+  'hifi_read_bases',
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
+  'hifi_num_reads',
+  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  'hifi_read_length_mean',
+  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  'barcode_quality_score_mean',
+  { data_type => 'smallint', extra => { unsigned => 1 }, is_nullable => 1 },
+  'hifi_read_quality_mean',
+  { data_type => 'smallint', extra => { unsigned => 1 }, is_nullable => 1 },
+  'hifi_bases_percent',
+  { data_type => 'float', is_nullable => 1 },
   'last_changed',
   {
     data_type => 'datetime',
@@ -191,8 +250,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-10-23 16:47:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hTT2fzNhcm/86YuT61o2Qw
+# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-01-19 13:58:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CBgNobCW7fHYVGPcg8ToYQ
 
 use Carp;
 

--- a/scripts/update_schema_6.31.0.sql
+++ b/scripts/update_schema_6.31.0.sql
@@ -13,3 +13,26 @@ ALTER TABLE `iseq_product_metrics` \
   ADD COLUMN `target_autosome_mapped_bases` bigint unsigned DEFAULT NULL \
     COMMENT 'The number of mapped bases passing the autosome target filters' \
     AFTER `target_autosome_length`;
+
+
+-- Add columns to pac_bio_product_metrics to store tag level yield.
+
+ALTER TABLE `pac_bio_product_metrics` \
+  ADD COLUMN  `hifi_read_bases`  bigint unsigned DEFAULT NULL \
+    COMMENT 'The number of HiFi bases' \
+    AFTER `qc`, \
+  ADD COLUMN  `hifi_num_reads` int unsigned DEFAULT NULL \
+    COMMENT 'The number of HiFi reads' \
+    AFTER `hifi_read_bases`, \
+  ADD COLUMN  `hifi_read_length_mean` int unsigned DEFAULT NULL \
+    COMMENT 'The mean HiFi read length' \
+    AFTER `hifi_num_reads`, \
+  ADD COLUMN  `hifi_read_quality_mean` smallint unsigned DEFAULT NULL \
+    COMMENT 'The mean HiFi base quality' \
+    AFTER  `hifi_read_length_mean`, \
+  ADD COLUMN  `hifi_bases_percent` float DEFAULT NULL \
+    COMMENT 'The HiFi bases expressed as a percentage of the total HiFi bases' \
+    AFTER  `hifi_read_quality_mean`, \
+  ADD COLUMN  `barcode_quality_score_mean` smallint unsigned DEFAULT NULL \
+    COMMENT 'The mean barcode HiFi quality score' \
+    AFTER `hifi_read_length_mean`;


### PR DESCRIPTION
Add columns to pac_bio_product_metrics to store tag level yield related metrics and bring other tables up to date.