### PR TITLE
Minor changes to the pac_bio_product_metrics table

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 LIST OF CHANGES
 ---------------
 
+ - Minor changes to the pac_bio_product_metrics table
+
 release 6.31.0
  - Additional columns added to the iseq_product_metrics table to support
    BGE library metrics reporting.

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqFlowcell.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqFlowcell.pm
@@ -158,7 +158,7 @@ Flowcell lane number
   is_nullable: 0
   size: 30
 
-Lane type: library, pool, library_control, library_indexed, library_indexed_spike
+Lane type: library, library_control, library_indexed, library_indexed_spike
 
 =head2 entity_id_lims
 
@@ -587,8 +587,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-10-23 16:35:44
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VjDSKdvECkCYaV1Nypjnzw
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-22 16:12:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qrc71Zkdjac/tHo55D3BbQ
 
 use MooseX::Aliases;
 use Readonly;

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/PacBioProductMetric.pm
@@ -103,6 +103,14 @@ The number of HiFi reads
 
 The mean HiFi read length
 
+=head2 barcode4deplexing
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 62
+
+The barcode recorded in producing deplexed metrics for this product
+
 =head2 barcode_quality_score_mean
 
   data_type: 'smallint'
@@ -110,14 +118,6 @@ The mean HiFi read length
   is_nullable: 1
 
 The mean barcode HiFi quality score
-
-=head2 hifi_read_quality_mean
-
-  data_type: 'smallint'
-  extra: {unsigned => 1}
-  is_nullable: 1
-
-The mean HiFi base quality
 
 =head2 hifi_bases_percent
 
@@ -154,9 +154,9 @@ __PACKAGE__->add_columns(
   { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
   'hifi_read_length_mean',
   { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  'barcode4deplexing',
+  { data_type => 'varchar', is_nullable => 1, size => 62 },
   'barcode_quality_score_mean',
-  { data_type => 'smallint', extra => { unsigned => 1 }, is_nullable => 1 },
-  'hifi_read_quality_mean',
   { data_type => 'smallint', extra => { unsigned => 1 }, is_nullable => 1 },
   'hifi_bases_percent',
   { data_type => 'float', is_nullable => 1 },
@@ -250,8 +250,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2024-01-19 13:58:19
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CBgNobCW7fHYVGPcg8ToYQ
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-22 16:12:30
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:2MEtm+C9VmoDlGZbAUSeKA
 
 use Carp;
 

--- a/scripts/update_schema_6.32.0.sql
+++ b/scripts/update_schema_6.32.0.sql
@@ -1,0 +1,7 @@
+-- Alter table pac_bio_product_metrics to remove hifi_read_quality_mean and add barcode4deplexing
+
+ALTER TABLE `pac_bio_product_metrics` \
+  DROP COLUMN hifi_read_quality_mean, \
+  ADD COLUMN  `barcode4deplexing` varchar(62)  DEFAULT NULL \
+    COMMENT 'The barcode recorded in producing deplexed metrics for this product' \
+    AFTER `hifi_read_length_mean`;


### PR DESCRIPTION
Minor changes to the pac_bio_product_metrics table - add field barcode4deplexing (to optionally store barcode identifiers used in any deplexing metrics stored in the table) and remove field hifi_read_quality_mean (as no longer calculated by PacBio).
Plus any other table updates.