### PR TITLE
Change iseq_product_metrics tag_decode_count from int to bigint

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+ - Change iseq_product_metrics tag_decode_count from int to bigint to support
+   values greater than 4294967295 and bring other tables up to date.
+  
 release 6.37.0 (2025-03-10)
  - Added 'lane_released' column to the existing iseq_run_lane_metrics table
    to capture the date of lane release.

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqProductMetric.pm
@@ -176,7 +176,7 @@ Indexing read length, bp
 
 =head2 tag_decode_count
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
@@ -780,7 +780,7 @@ __PACKAGE__->add_columns(
     size => [5, 2],
   },
   'tag_decode_count',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'insert_size_quartile1',
   { data_type => 'smallint', extra => { unsigned => 1 }, is_nullable => 1 },
   'insert_size_quartile3',
@@ -1112,8 +1112,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-12-13 14:21:19
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JGzaGF0Y9fdlAH5ZG6PYsA
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2025-03-31 14:29:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MRWBEnshcWTJ59FELH4KGw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/OseqFlowcell.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/OseqFlowcell.pm
@@ -246,6 +246,14 @@ The uuid of the run
 
 Run identifier assigned by MinKNOW
 
+=head2 rebasecalling_process
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 50
+
+Settings required for modified basecalling
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -328,6 +336,8 @@ __PACKAGE__->add_columns(
   { data_type => 'varchar', is_nullable => 1, size => 36 },
   'run_id',
   { data_type => 'varchar', is_nullable => 1, size => 255 },
+  'rebasecalling_process',
+  { data_type => 'varchar', is_nullable => 1, size => 50 },
 );
 
 =head1 PRIMARY KEY
@@ -375,8 +385,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07051 @ 2023-03-30 17:57:34
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sCzCqwiNhiXHH0eRKlKJUQ
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2025-03-31 14:29:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:S9Ut1yUfmbbMvaRYAojpWg
 
 our $VERSION = '0';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/Study.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/Study.pm
@@ -312,6 +312,24 @@ The data destination type(s) for the study. It could be 'standard', '14mg' or 'g
   is_nullable: 1
   size: 255
 
+=head2 ebi_library_strategy
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
+=head2 ebi_library_source
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
+=head2 ebi_library_selection
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -419,6 +437,12 @@ __PACKAGE__->add_columns(
   'contaminated_human_data_access_group',
   { data_type => 'varchar', is_nullable => 1, size => 255 },
   'programme',
+  { data_type => 'varchar', is_nullable => 1, size => 255 },
+  'ebi_library_strategy',
+  { data_type => 'varchar', is_nullable => 1, size => 255 },
+  'ebi_library_source',
+  { data_type => 'varchar', is_nullable => 1, size => 255 },
+  'ebi_library_selection',
   { data_type => 'varchar', is_nullable => 1, size => 255 },
 );
 
@@ -588,8 +612,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-10-09 15:42:26
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5p/5azacjlWMHTtTSrJtew
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2025-03-31 14:29:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zBqlb6BSFsCwFbHfII5V8A
 
 with 'WTSI::DNAP::Warehouse::Schema::Query::LimsFlags';
 

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/TolSampleBioproject.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/TolSampleBioproject.pm
@@ -61,7 +61,7 @@ __PACKAGE__->table('tol_sample_bioproject');
 =head2 library_type
 
   data_type: 'enum'
-  extra: {list => ['Chromium genome','Haplotagging','Hi-C','Hi-C - Arima v1','Hi-C - Arima v2','Hi-C - Dovetail','Hi-C - Omni-C','Hi-C - Qiagen','PacBio - CLR','PacBio - HiFi','ONT','RNA PolyA','RNA-seq dUTP eukaryotic','Standard','unknown','HiSeqX PCR free','PacBio - HiFi (ULI)','PacBio - IsoSeq','ATAC-seq']}
+  extra: {list => ['Chromium genome','Haplotagging','Hi-C','Hi-C - Arima v1','Hi-C - Arima v2','Hi-C - Dovetail','Hi-C - Omni-C','Hi-C - Qiagen','PacBio - CLR','PacBio - HiFi','ONT','RNA PolyA','RNA-seq dUTP eukaryotic','Standard','unknown','HiSeqX PCR free','PacBio - HiFi (ULI)','PacBio - IsoSeq','ATAC-seq','PacBio - HiFi (PiMmS)']}
   is_nullable: 1
 
 =head2 tolid
@@ -145,6 +145,7 @@ __PACKAGE__->add_columns(
         'PacBio - HiFi (ULI)',
         'PacBio - IsoSeq',
         'ATAC-seq',
+        'PacBio - HiFi (PiMmS)',
       ],
     },
     is_nullable => 1,
@@ -222,8 +223,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-10-09 15:42:26
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:P7s1muBNrElt8Hd3xqTL3w
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2025-03-31 14:29:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:f0vkprUgm/IZssygOBfOUw
 
 our $VERSION = '0';
 

--- a/scripts/update_schema_6.38.0.sql
+++ b/scripts/update_schema_6.38.0.sql
@@ -1,0 +1,6 @@
+--
+-- Change iseq_product_metrics tag_decode_count from int to bigint
+-- 
+
+ALTER TABLE `iseq_product_metrics`
+  MODIFY COLUMN tag_decode_count BIGINT UNSIGNED DEFAULT NULL;


### PR DESCRIPTION
Change iseq_product_metrics tag_decode_count from int to bigint to support values greater than 4294967295 and bring other tables up to date.