### PR TITLE
Factored out study and sample methods.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 LIST OF CHANGES
 ---------------
+
+ - In order to reduce code duplication the code that provides mapping of
+   st::api::lims methods to sample and study column names is moved to a
+   stand-alone role WTSI::DNAP::Warehouse::Schema::Query::CommonLimsData.
+   This role is consumed by both IseqFlowcell and UseqWafer result classes
+   thus ensuring that these classes provide a consistent way of accessing
+   sample and study properties.  
  
 release 6.43.0 (2026-02-18)
  - Added `ultimagen_application_type` column to `useq_product_metrics` table.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,7 @@
 Build.PL
 Changes
 lib/WTSI/DNAP/Warehouse/Schema.pm
+lib/WTSI/DNAP/Warehouse/Schema/Query/CommonLimsData.pm
 lib/WTSI/DNAP/Warehouse/Schema/Query/IseqFlowcell.pm
 lib/WTSI/DNAP/Warehouse/Schema/Query/LibraryDigest.pm
 lib/WTSI/DNAP/Warehouse/Schema/Result/Aliquot.pm

--- a/lib/WTSI/DNAP/Warehouse/Schema/Query/CommonLimsData.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Query/CommonLimsData.pm
@@ -1,0 +1,249 @@
+package WTSI::DNAP::Warehouse::Schema::Query::CommonLimsData;
+
+use Moose::Role;
+use Readonly;
+
+our $VERSION = '0';
+
+requires qw/sample study/;
+
+Readonly my @USER_ROLES => qw/manager follower owner/;
+
+Readonly my %DELEGATION_TO_SAMPLE => {
+    'sample_id'                => 'id_sample_lims',
+    'sample_uuid'              => 'uuid_sample_lims',
+    'sample_name'              => 'name',
+    'sample_lims'              => 'id_lims',
+    'sample_reference_genome'  => 'reference_genome',
+    'organism'                 => 'organism',
+    'sample_accession_number'  => 'accession_number',
+    'sample_common_name'       => 'common_name',
+    'sample_description'       => 'description',
+    'organism_taxon_id'        => 'taxon_id',
+    'sample_public_name'       => 'public_name',
+    'sample_consent_withdrawn' => 'consent_withdrawn',
+    'sample_supplier_name'     => 'supplier_name',
+    'sample_cohort'            => 'cohort',
+    'sample_donor_id'          => 'donor_id',
+    'sample_is_control'        => 'control',
+    'sample_control_type'      => 'control_type',
+};
+
+Readonly my %DELEGATION_TO_STUDY => {
+    'study_id'                            => 'id_study_lims',
+    'study_name'                          => 'name',
+    'study_reference_genome'              => 'reference_genome',
+    'study_accession_number'              => 'accession_number',
+    'study_description'                   => 'description',
+    'study_contains_nonconsented_human'   => 'contaminated_human_dna',
+    'study_title'                         => 'study_title',
+    'study_contains_nonconsented_xahuman' => 'remove_x_and_autosomes',
+    'study_alignments_in_bam'             => 'aligned',
+    'study_separate_y_chromosome_data'    => 'separate_y_chromosome_data',
+};
+
+foreach my $rel (qw(sample study)) {
+
+  my $attr = q[_] . $rel . q[_row];
+  my $del = $rel eq 'sample' ? \%DELEGATION_TO_SAMPLE : \%DELEGATION_TO_STUDY;
+
+  # Define two private attributes and set up method delegation. Note that
+  # the attributes are weak references to result objects. 
+  has $attr => (
+    isa        => 'Maybe[WTSI::DNAP::Warehouse::Schema::Result::' . ucfirst $rel . ']',
+    is         => 'ro',
+    weak_ref   => 1,
+    lazy_build => 1,
+    handles    => $del,
+  );
+
+  # Add a builder method for each of the attributes. The builder returns the
+  # study or sample relation.
+  __PACKAGE__->meta->add_method(
+    '_build_' . $attr, sub {my $r = shift; return $r->$rel;}
+  );
+
+  # A wrapper around the delegated methods ensures that if a linked study or
+  # sample record is not available, the method returns an undefined value
+  # rather than fails with a run-time error. 
+  foreach my $method ( keys %{$del} ) {
+    around $method => sub {
+      my ($orig, $self) = @_;
+      return $self->$attr ? $self->$orig() : undef;
+    };
+  }
+}
+
+has '_study_users' => ( isa        => 'HashRef',
+                        is         => 'ro',
+                        lazy_build => 1,
+);
+sub _build__study_users {
+  my $self = shift;
+  my $su = {};
+  my $study = $self->study();
+  if ($study) {
+    my $rs =  $study->study_users();
+    while (my $row = $rs->next) {
+      my $email_address = $row->email;
+      if ($email_address) { # Lots of NULLs in a database
+        push @{$su->{$row->role}}, $row->email;
+      }
+    }
+  }
+  return $su;
+}
+
+sub email_addresses {
+  my $self = shift;
+  my @emails = ();
+  foreach my $user_type (@USER_ROLES) {
+    if (exists $self->_study_users->{$user_type}) {
+      push @emails, map { $_ => 1 } @{$self->_study_users->{$user_type}};
+    }
+  }
+  my %hashed = @emails;
+  @emails = sort keys %hashed;
+  return \@emails;
+}
+
+foreach my $user_type (@USER_ROLES) {
+  my $method = 'email_addresses_of_' . $user_type . 's';
+  __PACKAGE__->meta->add_method($method, sub {
+    my $self = shift;
+    my @emails = ();
+    if (exists $self->_study_users->{$user_type}) {
+      @emails = sort values @{$self->_study_users->{$user_type}};
+    }
+    return \@emails;
+  });
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+WTSI::DNAP::Warehouse::Schema::Query::CommonLimsData
+
+=cut
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+A Moose role, a common interface for quering study and sample properties defined
+in the C<sample> and C<study> MLWH tables.
+
+A Result class that consumes this role should have both C<sample> and C<study>
+DBIx relation defined.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 SUBROUTINES/METHODS
+
+=head2 sample_id
+
+=head2 sample_uuid
+
+=head2 sample_name
+
+=head2 sample_lims
+
+=head2 sample_reference_genome
+
+=head2 organism
+
+=head2 sample_accession_number
+
+=head2 sample_common_name
+
+=head2 sample_description
+
+=head2 organism_taxon_id
+
+=head2 sample_public_name
+
+=head2 sample_consent_withdrawn
+
+=head2 sample_supplier_name
+
+=head2 sample_cohort
+
+=head2 sample_donor_id
+
+=head2 sample_is_control
+
+=head2 sample_control_type
+
+=head2 study_id
+
+=head2 study_name
+
+=head2 study_reference_genome
+
+=head2 study_accession_number
+
+=head2 study_description
+
+=head2 study_contains_nonconsented_human
+
+=head2 study_title
+
+=head2 study_contains_nonconsented_xahuman
+
+=head2 study_alignments_in_bam
+
+=head2 study_separate_y_chromosome_data
+
+=head2 email_addresses
+
+=head2 email_addresses_of_owners
+
+=head2 email_addresses_of_followers
+
+=head2 email_addresses_of_managers
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose::Role
+
+=item Readonly
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2026 Genome Research Ltd.
+
+This file is part of NPG software, ml_warehouse package
+L<https://github.com/wtsi-npg/ml_warehouse>.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqFlowcell.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/IseqFlowcell.pm
@@ -591,44 +591,10 @@ __PACKAGE__->belongs_to(
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qrc71Zkdjac/tHo55D3BbQ
 
 use MooseX::Aliases;
-use Readonly;
+
+with 'WTSI::DNAP::Warehouse::Schema::Query::CommonLimsData';
 
 our $VERSION = '0';
-
-Readonly my @USER_ROLES => qw/manager follower owner/;
-
-Readonly my %DELEGATION_TO_SAMPLE => {
-    'sample_id'                => 'id_sample_lims',
-    'sample_uuid'              => 'uuid_sample_lims',
-    'sample_name'              => 'name',
-    'sample_lims'              => 'id_lims',
-    'sample_reference_genome'  => 'reference_genome',
-    'organism'                 => 'organism',
-    'sample_accession_number'  => 'accession_number',
-    'sample_common_name'       => 'common_name',
-    'sample_description'       => 'description',
-    'organism_taxon_id'        => 'taxon_id',
-    'sample_public_name'       => 'public_name',
-    'sample_consent_withdrawn' => 'consent_withdrawn',
-    'sample_supplier_name'     => 'supplier_name',
-    'sample_cohort'            => 'cohort',
-    'sample_donor_id'          => 'donor_id',
-    'sample_is_control'        => 'control',
-    'sample_control_type'      => 'control_type',
-};
-
-Readonly my %DELEGATION_TO_STUDY => {
-    'study_id'                            => 'id_study_lims',
-    'study_name'                          => 'name',
-    'study_reference_genome'              => 'reference_genome',
-    'study_accession_number'              => 'accession_number',
-    'study_description'                   => 'description',
-    'study_contains_nonconsented_human'   => 'contaminated_human_dna',
-    'study_title'                         => 'study_title',
-    'study_contains_nonconsented_xahuman' => 'remove_x_and_autosomes',
-    'study_alignments_in_bam'             => 'aligned',
-    'study_separate_y_chromosome_data'    => 'separate_y_chromosome_data',
-};
 
 alias project_cost_code       => 'cost_code';
 alias default_library_type    => 'pipeline_id_lims';
@@ -642,28 +608,6 @@ alias gbs_plex_name           => 'primer_panel';
 sub qc_state {
   my $self = shift;
   return $self->iseq_product_metrics()->get_column(q[qc])->single();
-}
-
-foreach my $rel (qw(sample study)) {
-
-  my $attr = q[_] . $rel . q[_row];
-  my $del  = $rel eq 'sample' ? \%DELEGATION_TO_SAMPLE : \%DELEGATION_TO_STUDY;
-
-  has $attr => ( isa        => 'Maybe[WTSI::DNAP::Warehouse::Schema::Result::' . ucfirst $rel . ']',
-                 is         => 'ro',
-                 weak_ref   => 1,
-                 lazy_build => 1,
-                 handles    => $del,
-  );
-
-  __PACKAGE__->meta->add_method('_build_' . $attr, sub {my $r = shift; return $r->$rel;} );
-
-  foreach my $method ( keys %{$del} ) {
-    around $method => sub {
-      my ($orig, $self) = @_;
-      return $self->$attr ? $self->$orig() : undef;
-    };
-  }
 }
 
 has 'is_control' => ( isa        => 'Bool',
@@ -697,59 +641,15 @@ sub _build_required_insert_size_range {
   return $range;
 }
 
-has '_study_users' => ( isa        => 'HashRef',
-                        is         => 'ro',
-                        lazy_build => 1,
-);
-sub _build__study_users {
-  my $self = shift;
-  my $su = {};
-  my $study = $self->study();
-  if ($study) {
-    my $rs =  $study->study_users();
-    while (my $row = $rs->next) {
-      my $email_address = $row->email;
-      if ($email_address) { # Lots of NULLs in a database
-        push @{$su->{$row->role}}, $row->email;
-      }
-    }
-  }
-  return $su;
-}
-
 sub library_id {
   my $self = shift;
   return $self->legacy_library_id || $self->id_library_lims;
 }
 
-sub email_addresses {
-  my $self = shift;
-  my @emails = ();
-  foreach my $user_type (@USER_ROLES) {
-    if (exists $self->_study_users->{$user_type}) {
-      push @emails, map { $_ => 1 } @{$self->_study_users->{$user_type}};
-    }
-  }
-  my %hashed = @emails;
-  @emails = sort keys %hashed;
-  return \@emails;
-}
-
-foreach my $user_type (@USER_ROLES) {
-  my $method = 'email_addresses_of_' . $user_type . 's';
-  __PACKAGE__->meta->add_method($method, sub {
-    my $self = shift;
-    my @emails = ();
-    if (exists $self->_study_users->{$user_type}) {
-      @emails = sort values @{$self->_study_users->{$user_type}};
-    }
-    return \@emails;
-  });
-}
-
 __PACKAGE__->meta->make_immutable;
 
 1;
+
 __END__
 
 =head1 SYNOPSIS
@@ -786,54 +686,6 @@ change if the underlying values in the database change
 
 =head2 required_insert_size_range
 
-=head2 email_addresses
-
-=head2 email_addresses_of_owners
-
-=head2 email_addresses_of_followers
-
-=head2 email_addresses_of_managers
-
-=head2 sample_id
-
-=head2 sample_name
-
-=head2 sample_reference_genome
-
-=head2 organism
-
-=head2 sample_accession_number
-
-=head2 sample_common_name
-
-=head2 sample_description
-
-=head2 organism_taxon_id
-
-=head2 sample_public_name
-
-=head2 sample_consent_withdrawn
-
-=head2 study_id
-
-=head2 study_name
-
-=head2 study_reference_genome
-
-=head2 study_accession_number
-
-=head2 study_description
-
-=head2 study_contains_nonconsented_human
-
-=head2 study_title
-
-=head2 study_contains_nonconsented_xahuman
-
-=head2 study_alignments_in_bam
-
-=head2 study_separate_y_chromosome_data
-
 =head1 DEPENDENCIES
 
 =over
@@ -854,8 +706,6 @@ change if the underlying values in the database change
 
 =item DBIx::Class::InflateColumn::DateTime
 
-=item Readonly
-
 =back
 
 =head1 INCOMPATIBILITIES
@@ -868,9 +718,9 @@ Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2025 Genome Research Ltd.
+Copyright (C) 2014,2015,2016,2017,2018,2019,2020,2025,2026 Genome Research Ltd.
 
-This file is part of the ml_warehouse package L<https://github.com/wtsi-npg/ml_warehouse>.
+This file is part of NPG  ml_warehouse package L<https://github.com/wtsi-npg/ml_warehouse>.
 
 NPG is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/UseqWafer.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/UseqWafer.pm
@@ -499,63 +499,25 @@ __PACKAGE__->has_many(
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 
-use Readonly;
+use MooseX::Aliases;
+
+with 'WTSI::DNAP::Warehouse::Schema::Query::CommonLimsData';
 
 our $VERSION = '0';
 
-=head1 SUBROUTINES/METHODS
+sub tag2_sequence { return; }
 
-=head2 sample_id
-
-=head2 sample_name
-
-=head2 sample_supplier_name
-
-=head2 study_name
-
-=cut
-
-#####
-# Delegations below are provided to ensure compatibility with SeqQC viewer code.
-#
-
-Readonly my %DELEGATION_TO_SAMPLE => {
-    'sample_id'                => 'id_sample_lims',
-    'sample_name'              => 'name',
-    'sample_supplier_name'     => 'supplier_name',
-};
-
-Readonly my %DELEGATION_TO_STUDY => {
-    'study_name'                          => 'name',
-};
-
-foreach my $rel (qw(sample study)) {
-
-  my $attr = q[_] . $rel . q[_row];
-  my $del  = $rel eq 'sample' ? \%DELEGATION_TO_SAMPLE : \%DELEGATION_TO_STUDY;
-
-  has $attr => ( isa        => 'Maybe[WTSI::DNAP::Warehouse::Schema::Result::' . ucfirst $rel . ']',
-                 is         => 'ro',
-                 weak_ref   => 1,
-                 lazy_build => 1,
-                 handles    => $del,
-  );
-
-  __PACKAGE__->meta->add_method('_build_' . $attr, sub {my $r = shift; return $r->$rel;} );
-
-  foreach my $method ( keys %{$del} ) {
-    around $method => sub {
-      my ($orig, $self) = @_;
-      return $self->$attr ? $self->$orig() : undef;
-    };
-  }
-}
+alias default_library_type    => 'pipeline_id_lims';
+alias lane_id                 => 'entity_id_lims';
+alias default_tag_sequence    => 'tag_sequence';
+alias default_tagtwo_sequence => 'tag2_sequence';
+alias gbs_plex_name           => 'primer_panel';
+alias library_id              => 'id_library_lims';
+alias library_name            => 'id_library_lims';
 
 __PACKAGE__->meta->make_immutable;
 
 1;
-
-=head1 SUBROUTINES/METHODS
 
 =head1 SYNOPSIS
 
@@ -563,6 +525,43 @@ __PACKAGE__->meta->make_immutable;
 
 DBIx model for useq_wafer, which contains LIMS information for runs performed
 on Ultima Genomics instruments.
+
+=head1 SUBROUTINES/METHODS
+
+=head2 tag2_sequence
+
+Returns an undefined value.
+
+=head2 default_library_type
+
+Alias for C<pipeline_id_lims>.
+
+=head2 lane_id
+
+Alias for C<entity_id_lims>
+
+=head2 default_tag_sequence
+
+Alias for C<tag_sequence>
+
+=head2 default_tagtwo_sequence
+
+Alias for C<tag2_sequence>
+
+=head2 gbs_plex_name
+
+Alias for C<primer_panel>
+
+=head2 library_id 
+
+For Illumina data we map C<library_id> to c<legacy_library_id>, see
+WTSI::DNAP::Warehouse::Schema::Result::IseqFlowcell. The latter is not
+currently available in this table, so C<library_id> is mapped here to
+C<id_library_lims>, which for Illumina data is a fallback.
+
+=head2 library_name
+
+Alias for C<id_library_lims>
 
 =head1 CONFIGURATION AND ENVIRONMENT
 


### PR DESCRIPTION
In order to reduce code duplication the code that provides mapping of st::api::lims methods to sample and study column names is moved to a stand-alone role.