### PR TITLE
Add location table relation in ORM for Ultimagen and Elembio

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES
 ---------------
 
+ - Add location table relation in ORM for Ultimagen and Elembio
+   product metrics
+
 release 6.45.0 (2026-04-15)
  - Add fields to pac_bio_run_well_metrics to capture multi-use SMRT cell
    information relating to the new PacBio SPRQ-Nx consumables.

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/EseqProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/EseqProductMetric.pm
@@ -336,6 +336,23 @@ use MooseX::Aliases;
 
 our $VERSION = '0';
 
+=head2 seq_product_irods_locations
+
+Type: has_many
+
+Related object: L<WTSI::DNAP::Warehouse::Schema::Result::SeqProductIrodsLocation>
+
+=cut
+
+__PACKAGE__->has_many(
+  'seq_product_irods_locations',
+  'WTSI::DNAP::Warehouse::Schema::Result::SeqProductIrodsLocation',
+  {
+    'foreign.id_product' => 'self.id_eseq_product',
+  },
+  { is_deferrable => 1, cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head1 SUBROUTINES/METHODS
 
 =head2 position

--- a/lib/WTSI/DNAP/Warehouse/Schema/Result/UseqProductMetric.pm
+++ b/lib/WTSI/DNAP/Warehouse/Schema/Result/UseqProductMetric.pm
@@ -351,6 +351,23 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 1, on_delete => 'CASCADE', on_update => 'RESTRICT' },
 );
 
+=head2 seq_product_irods_locations
+
+Type: has_many
+
+Related object: L<WTSI::DNAP::Warehouse::Schema::Result::SeqProductIrodsLocation>
+
+=cut
+
+__PACKAGE__->has_many(
+  'seq_product_irods_locations',
+  'WTSI::DNAP::Warehouse::Schema::Result::SeqProductIrodsLocation',
+  {
+    'foreign.id_product' => 'self.id_useq_product',
+  },
+  { is_deferrable => 1, cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head1 SUBROUTINES/METHODS
 
 =head2 position


### PR DESCRIPTION
Add the relation to `seq_product_irods_location` table to `Elembio` and `Ultimagen` product ORM